### PR TITLE
Fix typo in documentation

### DIFF
--- a/assets/snippets/stripe-elements/card-sample.md
+++ b/assets/snippets/stripe-elements/card-sample.md
@@ -21,7 +21,7 @@ export default {
       token: null,
     };
   },
-  method: {
+  methods: {
     submit () {
       // this will trigger the process
       this.$refs.elementRef.submit();


### PR DESCRIPTION
This should be `methods:` not `method:`